### PR TITLE
タグ作成/編集/更新機能実装、検索機能にタグ名を含まれるよう改修

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -2,7 +2,7 @@ class PostsController < ApplicationController
   skip_before_action :require_login, only: %i[index show]
   def index
     @q = Post.ransack(params[:q])
-    @posts = @q.result(distinct: true)
+    @posts = @q.result(distinct: true).includes(:post_tags, :tags).order(created_at: :desc)
   end
 
   def show
@@ -29,7 +29,7 @@ class PostsController < ApplicationController
   def update
     @post = find_post(params[:id])
     if @post.update(post_params)
-      redirect_to root_path
+      redirect_to post_path(@post.id)
     else
       render :edit, status: :unprocessable_entity
     end
@@ -48,6 +48,6 @@ class PostsController < ApplicationController
   end
 
   def post_params
-    params.require(:post).permit(:title, :content)
+    params.require(:post).permit(:title, :content, :tag_names)
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -2,13 +2,34 @@ class Post < ApplicationRecord
   validates :title, presence: true, length: { maximum: 255 }
   validates :content, presence: true, length: { maximum: 65_535 }
 
+  attr_accessor :tag_names
+  before_save :save_tags
+
+  # Ransackで検索可能にするフィールド
   def self.ransackable_attributes(auth_object = nil)
     ["title", "content"]
   end
 
+  # Ransackで検索可能にするアソシエーション
   def self.ransackable_associations(auth_object = nil)
-    ["user"]
+    ["user", "tags"]
   end
 
   belongs_to :user
+  has_many :post_tags, dependent: :destroy
+  has_many :tags, through: :post_tags
+
+  private
+
+  def save_tags
+    self.tags.clear
+    if tag_names.present?
+      tag_names.split(',').map(&:strip).uniq.reject(&:empty?).each do |tag_name|
+        # 既存のタグを利用or新しいタグを作成する
+        tag = Tag.find_or_create_by(name: tag_name)
+        self.tags << tag
+      end
+    end
+  end
 end
+

--- a/app/models/post_tag.rb
+++ b/app/models/post_tag.rb
@@ -1,0 +1,4 @@
+class PostTag < ApplicationRecord
+  belongs_to :post
+  belongs_to :tag
+end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,0 +1,10 @@
+class Tag < ApplicationRecord
+  validates :name, presence: true, length: { minimum: 2, maximum: 50 }, uniqueness: { case_sensitive: false }
+  has_many :post_tags, dependent: :destroy
+  has_many :posts, through: :post_tags
+
+  # Ransackで検索可能にするフィールド
+  def self.ransackable_attributes(auth_object = nil)
+    ["name"]
+  end
+end

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,0 +1,9 @@
+<%= form_with model: post do |f| %>
+  <%= f.label :title %>
+  <%= f.text_field :title %>
+  <%= f.label :content %>
+  <%= f.text_area :content %>
+  <%= f.label :tag_names, "タグ" %>
+  <%= f.text_field :tag_names, value: post.tags.map(&:name).join(', ') %>
+  <%= f.submit post.new_record? ? '投稿する' : '更新する' %>
+<% end %>

--- a/app/views/posts/_search_form.html.erb
+++ b/app/views/posts/_search_form.html.erb
@@ -1,6 +1,6 @@
 <%= search_form_for @q, url: root_path do |f| %>
-  <%= f.label :title_or_content_cont %>
-  <%= f.search_field :title_or_content_cont %>
+  <%= f.label :title_or_content_or_tag_name_cont %>
+  <%= f.search_field :title_or_content_or_tags_name_cont %>
 
   <%= f.submit %>
 <% end %>

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -1,9 +1,3 @@
 <h1>編集</h1>
-<%= form_with model: @post do |f| %>
-  <%= f.label :title %>
-  <%= f.text_field :title %>
-  <%= f.label :content %>
-  <%= f.text_area :content %>
-  <%= f.submit '更新' %>
-<% end %>
+<%= render 'form', post: @post %>
 <%= link_to "戻る", root_path %>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,9 +1,3 @@
 <h1>新規作成</h1>
-<%= form_with model: @post do |f| %>
-  <%= f.label :title %>
-  <%= f.text_field :title %>
-  <%= f.label :content %>
-  <%= f.text_area :content %>
-  <%= f.submit '投稿' %>
-<% end %>
+<%= render 'form', post: @post %>
 <%= link_to "戻る", root_path %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,6 +1,9 @@
-<h3><%= @post.title %></h3>
-<p><%= @post.content %></p>
-<p><%= @post.user_id %></p>
+<h3>タイトル：<%= @post.title %></h3>
+<p>内容：<%= @post.content %></p>
+<p>投稿者：<%= @post.user_id %></p>
+<% if @post.tags.any? %>
+  <p>タグ：<%= @post.tags.map(&:name).join(', ') %></p>
+<% end %>
 <% if current_user && current_user.id == @post.user_id %>
   <%= link_to "編集", edit_post_path(@post) %>
 <% end%>

--- a/db/migrate/20250711235502_create_tags.rb
+++ b/db/migrate/20250711235502_create_tags.rb
@@ -1,0 +1,9 @@
+class CreateTags < ActiveRecord::Migration[7.1]
+  def change
+    create_table :tags do |t|
+      t.string :name, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250711235524_create_post_tags.rb
+++ b/db/migrate/20250711235524_create_post_tags.rb
@@ -1,0 +1,9 @@
+class CreatePostTags < ActiveRecord::Migration[7.1]
+  def change
+    create_table :post_tags do |t|
+      t.references :post, foreign_key: true
+      t.references :tag, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_07_09_125423) do
+ActiveRecord::Schema[7.1].define(version: 2025_07_11_235524) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "post_tags", force: :cascade do |t|
+    t.bigint "post_id"
+    t.bigint "tag_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["post_id"], name: "index_post_tags_on_post_id"
+    t.index ["tag_id"], name: "index_post_tags_on_tag_id"
+  end
 
   create_table "posts", force: :cascade do |t|
     t.string "title"
@@ -21,6 +30,12 @@ ActiveRecord::Schema[7.1].define(version: 2025_07_09_125423) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_posts_on_user_id"
+  end
+
+  create_table "tags", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "users", force: :cascade do |t|
@@ -33,5 +48,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_07_09_125423) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "post_tags", "posts"
+  add_foreign_key "post_tags", "tags"
   add_foreign_key "posts", "users"
 end

--- a/test/fixtures/post_tags.yml
+++ b/test/fixtures/post_tags.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/tags.yml
+++ b/test/fixtures/tags.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+
+two:
+  name: MyString

--- a/test/models/post_tag_test.rb
+++ b/test/models/post_tag_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class PostTagTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/tag_test.rb
+++ b/test/models/tag_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class TagTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要
- Tagsテーブルと中間テーブルになるPostTagsを作成
- Postsテーブルとのアソシエーション形成
- タグ関連のCRUDを整備
- Ransackの検索対象にタグ名を追加