### PR TITLE
Fetch note posts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,7 @@ gem "sorcery"
 gem 'ransack'
 gem 'kaminari'
 gem 'bootstrap5-kaminari-views'
+gem 'rss'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,7 @@ gem 'ransack'
 gem 'kaminari'
 gem 'bootstrap5-kaminari-views'
 gem 'rss'
+gem 'nokogiri', '~> 1.16'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -262,6 +262,8 @@ GEM
     reline (0.6.1)
       io-console (~> 0.5)
     rexml (3.4.1)
+    rss (0.3.1)
+      rexml
     ruby-vips (2.2.4)
       ffi (~> 1.12)
       logger
@@ -334,6 +336,7 @@ DEPENDENCIES
   puma (>= 5.0)
   rails (~> 7.1.5, >= 7.1.5.1)
   ransack
+  rss
   selenium-webdriver
   sorcery
   sprockets-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -332,6 +332,7 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   kaminari
+  nokogiri (~> 1.16)
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.1.5, >= 7.1.5.1)

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,7 +1,7 @@
 <%= render 'search_form' %>
 <% @posts.each do |post| %>
   <li><%= link_to post.title, post_path(post) %>
-    <% if current_user && current_user.id == post.user_id %>
+    <% if current_user && current_user.id == post.user_id && !post.is_note_article %>
       <span><%= link_to "削除", post_path(post), data: { turbo_method: :delete, confirm: "本当に削除しますか？" } %></span>
     <% end %>
   </li>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,10 +1,22 @@
 <%= render 'search_form' %>
 <% @posts.each do |post| %>
-  <li><%= link_to post.title, post_path(post) %>
-    <% if current_user && current_user.id == post.user_id && !post.is_note_article %>
+  <div>
+    <% if post.is_note_article? && post.note_thumbnail_url.present? %>
+      <div class="note-thumbnail">
+        <%= image_tag post.note_thumbnail_url, alt: post.title, style: "max-width: 150px; height: auto; margin-right: 10px;" %>
+      </div>
+    <% elsif !post.is_note_article? && post.thumbnail.attached? %>
+      <div class="post-thumbnail">
+        <%= image_tag post.thumbnail.variant(resize_to_limit: [150, 150]), alt: post.title %>
+      </div>
+    <% end %>
+  </div>
+  <div>
+    <%= link_to post.title, post_path(post) %>
+    <% if current_user && current_user.id == post.user_id %>
       <span><%= link_to "削除", post_path(post), data: { turbo_method: :delete, confirm: "本当に削除しますか？" } %></span>
     <% end %>
-  </li>
+  </div>
 <% end %>
 <%= paginate @posts, theme: 'bootstrap-5' %>
 <% if current_user %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -3,12 +3,12 @@
   <%= image_tag @post.thumbnail.variant(resize_to_limit: [200, 100]), alt: @post.title %>
 <% end %>
 <p>内容：<%= @post.content %></p>
-<p>投稿者：<%= @post.user_id %></p>
+<p>投稿者：<%= @post.user.name %></p>
 <% if @post.tags.any? %>
   <p>タグ：<%= @post.tags.map(&:name).join(', ') %></p>
 <% end %>
-<% if current_user && current_user.id == @post.user_id %>
+<% if current_user && current_user.id == @post.user_id && !@post.is_note_article %>
   <%= link_to "編集", edit_post_path(@post) %>
-  <%= link_to "削除", post_path(post), data: { turbo_method: :delete, confirm: "本当に削除しますか？" } %>
+  <%= link_to "削除", post_path(@post), data: { turbo_method: :delete, confirm: "本当に削除しますか？" } %>
 <% end%>
 <%= link_to "戻る", root_path %>

--- a/db/migrate/20250714094537_add_note_fields_to_posts.rb
+++ b/db/migrate/20250714094537_add_note_fields_to_posts.rb
@@ -1,0 +1,6 @@
+class AddNoteFieldsToPosts < ActiveRecord::Migration[7.1]
+  def change
+    add_column :posts, :note_url, :string
+    add_column :posts, :is_note_article, :boolean, default: false
+  end
+end

--- a/db/migrate/20250714104143_add_note_thumbnail_url_to_posts.rb
+++ b/db/migrate/20250714104143_add_note_thumbnail_url_to_posts.rb
@@ -1,0 +1,5 @@
+class AddNoteThumbnailUrlToPosts < ActiveRecord::Migration[7.1]
+  def change
+    add_column :posts, :note_thumbnail_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_07_14_011436) do
+ActiveRecord::Schema[7.1].define(version: 2025_07_14_094537) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -67,6 +67,8 @@ ActiveRecord::Schema[7.1].define(version: 2025_07_14_011436) do
     t.bigint "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "note_url"
+    t.boolean "is_note_article", default: false
     t.index ["user_id"], name: "index_posts_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_07_14_094537) do
+ActiveRecord::Schema[7.1].define(version: 2025_07_14_104143) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -69,6 +69,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_07_14_094537) do
     t.datetime "updated_at", null: false
     t.string "note_url"
     t.boolean "is_note_article", default: false
+    t.string "note_thumbnail_url"
     t.index ["user_id"], name: "index_posts_on_user_id"
   end
 

--- a/lib/tasks/note.rake
+++ b/lib/tasks/note.rake
@@ -1,0 +1,44 @@
+# lib/tasks/note.rake
+require 'rss'
+require 'open-uri'
+
+namespace :note do
+  desc "Noteに投稿した記事のインポート"
+  task import_posts: :environment do
+    NOTE_RSS_URL = 'https://note.com/kei2kei/rss'
+    importer_user = User.first
+    puts "インポート開始"
+
+    begin
+      rss = RSS::Parser.parse(URI.open(NOTE_RSS_URL).read, false)
+      rss.items.each do |item|
+        # Note記事のURLが既に存在するかチェックして重複を避ける
+        # 同じ記事を複数回インポートしないようにチェック
+        unless Post.exists?(note_url: item.link)
+          # PostモデルにNote記事として保存
+          Post.create!(
+            title: item.title, #Noteの記事のタイトル
+            content: item.description, # contentをそのまま使うか、HTMLを加工するか検討
+            note_url: item.link, # Noteの元のURL
+            is_note_article: true,
+            created_at: item.pubDate, # Noteの公開日時をそのまま使用
+            updated_at: item.pubDate, # Noteの公開日時をそのまま使用
+            user: importer_user
+          )
+          puts "インポートした記事: #{item.title}"
+        else
+          # 既に存在する場合はスキップ
+          puts "スキップ: #{item.title} (既にインポート済み)"
+        end
+      end
+      puts "インポート完了"
+    rescue OpenURI::HTTPError => e
+      puts "エラー: Note RSSフィードの取得に失敗しました。URLを確認してください。#{e.message}"
+    rescue RSS::NotWellFormedError => e
+      puts "エラー: 取得したRSSフィードの形式が不正です。#{e.message}"
+    rescue => e
+      puts "予期せぬエラーが発生しました: #{e.message}"
+      puts e.backtrace.join("\n")
+    end
+  end
+end


### PR DESCRIPTION
## 概要
- rssとnokogiriパッケージインストール
- rakeファイルを作成し、noteのAPIから記事の情報を取得
- Postsテーブルにnoteの記事を追加できるよう設定
- nokogiriでNoteAPIのXML内からサムネイルのURLを取得
- サムネイルを一覧画面で表示できるよう修正