### PR TITLE
Githubからのコントリビューション（草）のデータ取得

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,7 @@ gem 'kaminari'
 gem 'bootstrap5-kaminari-views'
 gem 'rss'
 gem 'nokogiri', '~> 1.16'
+gem 'dotenv-rails'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,6 +107,10 @@ GEM
     debug (1.11.0)
       irb (~> 1.10)
       reline (>= 0.3.8)
+    dotenv (3.1.8)
+    dotenv-rails (3.1.8)
+      dotenv (= 3.1.8)
+      railties (>= 6.1)
     drb (2.2.3)
     erb (5.0.1)
     erubi (1.13.1)
@@ -328,6 +332,7 @@ DEPENDENCIES
   bootstrap5-kaminari-views
   capybara
   debug
+  dotenv-rails
   image_processing (~> 1.2)
   importmap-rails
   jbuilder

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -3,6 +3,9 @@ class PostsController < ApplicationController
   def index
     @q = Post.ransack(params[:q])
     @posts = @q.result(distinct: true).includes(:post_tags, :tags).order(created_at: :desc).page params[:page]
+    # 一覧画面のカレンダーに合わせ週初め（日曜）〜週終わり（土曜）までのコントリビューションのデータを取得
+    today = Date.today
+    @git_hub_contributions = GitHubContribution.where(date: (today.beginning_of_week - 1)..(today.end_of_week - 1)).order(:date)
   end
 
   def show

--- a/app/models/git_hub_contribution.rb
+++ b/app/models/git_hub_contribution.rb
@@ -1,0 +1,3 @@
+class GitHubContribution < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,4 +7,5 @@ class User < ApplicationRecord
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }
 
   has_many :posts, dependent: :destroy
+  has_many :git_hub_contributions, dependent: :destroy
 end

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,3 +1,22 @@
+<div class="contribution-calendar">
+  <ul class="week-days">
+    <div>日</div>
+    <div>月</div>
+    <div>火</div>
+    <div>水</div>
+    <div>木</div>
+    <div>金</div>
+    <div>土</div>
+  </ul>
+  <div class="contribution-grid">
+    <% @git_hub_contributions.each do |contribution| %>
+      <div class="contribution-day" style="background-color: <%= contribution.color %>;">
+        <%= contribution.contribution_count %>
+        <%= contribution.date.day %>
+      </div>
+    <% end %>
+  </div>
+</div>
 <%= render 'search_form' %>
 <% @posts.each do |post| %>
   <div>

--- a/db/migrate/20250715055753_create_git_hub_contributions.rb
+++ b/db/migrate/20250715055753_create_git_hub_contributions.rb
@@ -1,0 +1,13 @@
+class CreateGitHubContributions < ActiveRecord::Migration[7.1]
+  def change
+    create_table :git_hub_contributions do |t|
+      t.date :date, null: false
+      t.string :color, null: false
+      t.integer :contribution_count, default: 0
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :git_hub_contributions, [:user_id, :date], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_07_14_104143) do
+ActiveRecord::Schema[7.1].define(version: 2025_07_15_055753) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -52,6 +52,17 @@ ActiveRecord::Schema[7.1].define(version: 2025_07_14_104143) do
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
+  create_table "git_hub_contributions", force: :cascade do |t|
+    t.date "date", null: false
+    t.string "color", null: false
+    t.integer "contribution_count", default: 0
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id", "date"], name: "index_git_hub_contributions_on_user_id_and_date", unique: true
+    t.index ["user_id"], name: "index_git_hub_contributions_on_user_id"
+  end
+
   create_table "post_tags", force: :cascade do |t|
     t.bigint "post_id"
     t.bigint "tag_id"
@@ -91,6 +102,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_07_14_104143) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "git_hub_contributions", "users"
   add_foreign_key "post_tags", "posts"
   add_foreign_key "post_tags", "tags"
   add_foreign_key "posts", "users"

--- a/lib/tasks/github.rake
+++ b/lib/tasks/github.rake
@@ -1,0 +1,69 @@
+require "net/http"
+require "json"
+require "json/add/core"
+require "open-uri"
+require "uri"
+
+namespace :github do
+  desc "Github上からコントリビューションのデータをインポート"
+  task import_contributions: :environment do
+    user = User.first
+    query = <<~GRAPHQL
+      query {
+        user(login: "kei2kei") {
+          contributionsCollection {
+            contributionCalendar {
+              weeks {
+                contributionDays {
+                  date,
+                  color,
+                  contributionCount
+                }
+              }
+            }
+          }
+        }
+      }
+    GRAPHQL
+
+    token = ENV["GITHUB_TOKEN"]
+    endpoint_url = "https://api.github.com/graphql"
+
+    uri = URI.parse(endpoint_url)
+    https = Net::HTTP.new(uri.host, uri.port)
+    https.use_ssl = true
+
+    request_header = {
+      "Authorization": "bearer #{token}",
+      "Content-Type": "application/json"
+    }
+    begin
+      request = Net::HTTP::Post.new(uri.request_uri, request_header)
+      request.body = JSON.generate({ query: query })
+
+      response = https.request(request)
+      response_body = JSON.parse(response.body)
+
+      # 昨日のデータを抽出、nilエラーを防ぐためdigを使用
+      data_of_yesterday = response_body.dig("data", "user", "contributionsCollection", "contributionCalendar", "weeks", -1, "contributionDays", -2)
+      # date_of_yesterdayにはその日の日付、色（草の色）、コントリビューション数が入っている。
+      date, color, contribution_count = data_of_yesterday.values_at("date", "color", "contributionCount") if data_of_yesterday
+      puts '--------'
+      puts date
+      puts color
+      puts contribution_count
+      # テーブルへの保存、重複回避のためにfind_or_initializeを使用し、レコードが新しいか確認
+      contribution = user.git_hub_contributions.find_or_initialize_by(user_id: user.id, date: date)
+      if contribution.new_record?
+        contribution.color = color
+        contribution.contribution_count = contribution_count
+        contribution.save!
+      end
+      puts "インポート完了"
+    rescue => e
+      puts "GitHub APIエラー: #{e.message}"
+      puts e.backtrace.join("\n")
+    end
+  end
+end
+

--- a/test/fixtures/git_hub_contributions.yml
+++ b/test/fixtures/git_hub_contributions.yml
@@ -1,0 +1,13 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  date: 2025-07-15
+  color: MyString
+  contribution_count: 1
+  user: one
+
+two:
+  date: 2025-07-15
+  color: MyString
+  contribution_count: 1
+  user: two

--- a/test/models/git_hub_contribution_test.rb
+++ b/test/models/git_hub_contribution_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class GitHubContributionTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要
- Graphql APIの取得のためNet::HTTPを使ってHTTPSリクエストを作成。
- Githubのエクスプローラーで作成したクエリをリクエストに付与し、日付、草の色、コントリビューション数を取得
- 取得したデータを保存するGitHubContributionsテーブル作成、Userと関連づける
- ビューに簡易的に表示、デザインは別途修正する予定