### PR TITLE
Markdown機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,7 @@ gem 'bootstrap5-kaminari-views'
 gem 'rss'
 gem 'nokogiri', '~> 1.16'
 gem 'dotenv-rails'
+gem 'kramdown'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,7 +112,7 @@ GEM
       dotenv (= 3.1.8)
       railties (>= 6.1)
     drb (2.2.3)
-    erb (5.0.1)
+    erb (5.0.2)
     erubi (1.13.1)
     faraday (2.13.2)
       faraday-net_http (>= 2.0, < 3.5)
@@ -134,7 +134,7 @@ GEM
       actionpack (>= 6.0.0)
       activesupport (>= 6.0.0)
       railties (>= 6.0.0)
-    io-console (0.8.0)
+    io-console (0.8.1)
     irb (1.15.2)
       pp (>= 0.6.0)
       rdoc (>= 4.0.0)
@@ -142,7 +142,7 @@ GEM
     jbuilder (2.13.0)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
-    json (2.12.2)
+    json (2.13.0)
     jwt (3.1.2)
       base64
     kaminari (1.2.2)
@@ -157,6 +157,8 @@ GEM
       activerecord
       kaminari-core (= 1.2.2)
     kaminari-core (1.2.2)
+    kramdown (2.5.1)
+      rexml (>= 3.3.9)
     logger (1.7.0)
     loofah (2.24.1)
       crass (~> 1.0.2)
@@ -297,7 +299,7 @@ GEM
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     stringio (3.1.7)
-    thor (1.3.2)
+    thor (1.4.0)
     timeout (0.4.3)
     turbo-rails (2.0.16)
       actionpack (>= 7.1.0)
@@ -337,6 +339,7 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   kaminari
+  kramdown
   nokogiri (~> 1.16)
   pg (~> 1.1)
   puma (>= 5.0)

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -1,2 +1,7 @@
 module PostsHelper
+  # 記事の内容(マークダウン)を保存前にHTMLにする
+  def rendered_content_html(markdown_content)
+    sanitized_html = sanitize Kramdown::Document.new(markdown_content).to_html
+    raw(sanitized_html)
+  end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -16,7 +16,6 @@ class Post < ApplicationRecord
     ["user", "tags"]
   end
 
-  has_rich_text :content
   has_one_attached :thumbnail
 
   belongs_to :user

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -4,7 +4,7 @@
   <%= f.label :title %>
   <%= f.text_field :title %>
   <%= f.label :content %>
-  <%= f.rich_text_area :content %>
+  <%= f.text_area :content %>
   <%= f.label :tag_names, "タグ" %>
   <%= f.text_field :tag_names, value: post.tags.map(&:name).join(', ') %>
   <%= f.submit post.new_record? ? '投稿する' : '更新する' %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -2,7 +2,7 @@
 <% if @post.thumbnail.attached? %>
   <%= image_tag @post.thumbnail.variant(resize_to_limit: [200, 100]), alt: @post.title %>
 <% end %>
-<p>内容：<%= @post.content %></p>
+<p>内容：<%= rendered_content_html(@post.content) %></p>
 <p>投稿者：<%= @post.user.name %></p>
 <% if @post.tags.any? %>
   <p>タグ：<%= @post.tags.map(&:name).join(', ') %></p>

--- a/db/migrate/20250718232432_remove_action_text_rich_table.rb
+++ b/db/migrate/20250718232432_remove_action_text_rich_table.rb
@@ -1,0 +1,5 @@
+class RemoveActionTextRichTable < ActiveRecord::Migration[7.1]
+  def change
+    drop_table :action_text_rich_texts
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,19 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_07_15_055753) do
+ActiveRecord::Schema[7.1].define(version: 2025_07_18_232432) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-
-  create_table "action_text_rich_texts", force: :cascade do |t|
-    t.string "name", null: false
-    t.text "body"
-    t.string "record_type", null: false
-    t.bigint "record_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["record_type", "record_id", "name"], name: "index_action_text_rich_texts_uniqueness", unique: true
-  end
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false


### PR DESCRIPTION
## 概要
- 機能の競合が起きるため、ActionRichTextの設定を削除
- Kramdownをインストール
- ヘルパーにて入力された内容（Markdown）をHTMLに変換する処理実装
- HTML変換後に標準のsanitaizeをかけHTMLの安全性担保