### PR TITLE
ベストアンサー機能の実装

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -4,4 +4,5 @@ class Comment < ApplicationRecord
   belongs_to :user
   belongs_to :parent_comment, class_name: 'Comment', optional: true
   has_many :replies, class_name: 'Comment', foreign_key: :parent_id, dependent: :destroy
+  has_one :best_comment_of_post, class_name: 'Post', foreign_key: :best_comment_id
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -22,6 +22,7 @@ class Post < ApplicationRecord
   has_many :post_tags, dependent: :destroy
   has_many :tags, through: :post_tags
   has_many :comments, dependent: :destroy
+  belongs_to :best_comment, class_name: "Comment", optional: true
 
   private
 

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,15 +1,21 @@
-<% comments.each do |comment| %>
-  <div class="comment ml-20" data-controller="comment">
-    <p>回答者：<%= comment.user.name %></p>
-    <p>内容：<%= comment.content %></p>
-    <% if current_user && current_user.id == comment.user.id %>
-      <p><%= link_to "削除", post_comment_path(post,comment), data: { turbo_method: :delete, confirm: "本当に削除しますか？" } %></p>
-    <% end%>
-    <button data-action="click->comment#showReplyForm" data-comment-id="<%= comment.id %>">返信</button>
-    <% if comment.replies.any? %>
-      <div class="replies">
-        <%= render partial: 'comments/reply', locals: { replies: comment.replies, post: @post } %>
-      </div>
-    <% end %>
-  </div>
-<% end %>
+<div class="comment ml-20" data-controller="comment">
+  <% if post.best_comment_id == comment.id %>
+    <i>ベストアンサー</i>
+  <% end %>
+  <% if current_user == post.user && post.best_comment_id.nil? %>
+    <%= button_to "ベストアンサーに選ぶ", set_best_comment_comment_path(comment), method: :patch %>
+  <% end %>
+  <p>回答者：<%= comment.user.name %></p>
+  <p>内容：<%= comment.content %></p>
+  <% if current_user && current_user.id == comment.user.id %>
+    <p><%= link_to "削除", post_comment_path(post,comment), data: { turbo_method: :delete, confirm: "本当に削除しますか？" } %></p>
+  <% end%>
+  <button data-action="click->comment#showReplyForm" data-comment-id="<%= comment.id %>">返信</button>
+  <% if comment.replies.any? %>
+    <div class="replies">
+      <% comment.replies.each do |reply| %>
+        <%= render partial: 'comments/reply', locals: { reply: reply, post: post } %>
+      <% end %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/comments/_reply.html.erb
+++ b/app/views/comments/_reply.html.erb
@@ -1,10 +1,8 @@
-<% replies.each_with_index do |reply, index| %>
-  <div class="comment ml-40" data-controller="comment">
-    <p>回答者：<%= reply.user.name %></p>
-    <p>コメント：<%= reply.content %></p>
-    <% if current_user && current_user.id == reply.user.id %>
-      <p><%= link_to "削除", post_comment_path(post,reply), data: { turbo_method: :delete, confirm: "本当に削除しますか？" } %></p>
-    <% end%>
-    <button data-action="click->comment#showReplyForm" data-comment-id="<%= reply.id %>">返信</button>
-  </div>
-<% end %>
+<div class="comment ml-40" data-controller="comment">
+  <p>回答者：<%= reply.user.name %></p>
+  <p>コメント：<%= reply.content %></p>
+  <% if current_user && current_user.id == reply.user.id %>
+    <p><%= link_to "削除", post_comment_path(post,reply), data: { turbo_method: :delete, confirm: "本当に削除しますか？" } %></p>
+  <% end%>
+  <button data-action="click->comment#showReplyForm" data-comment-id="<%= reply.id %>">返信</button>
+</div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -8,7 +8,9 @@
   <p>タグ：<%= @post.tags.map(&:name).join(', ') %></p>
 <% end %>
 <%= render 'comments/form', comment: @comment, parent_comment: @parent_comment, post: @post %>
-<%= render 'comments/comment', comments: @comments, post: @post %>
+<% @comments.each do |comment| %>
+  <%= render 'comments/comment', comment: comment, post: @post %>
+<% end %>
 <% if current_user && current_user.id == @post.user_id %>
   <%= link_to "編集", edit_post_path(@post) %>
   <%= link_to "削除", post_path(@post), data: { turbo_method: :delete, confirm: "本当に削除しますか？" } %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,11 @@ Rails.application.routes.draw do
       get :new_reply
     end
   end
+  resources :comments, only: [] do
+    member do
+      patch :set_best_comment
+    end
+  end
   root 'posts#index'
   get 'tags/search', to: 'tags#search'
   devise_scope :user do

--- a/db/migrate/20250823082052_add_best_answer_id_to_posts.rb
+++ b/db/migrate/20250823082052_add_best_answer_id_to_posts.rb
@@ -1,0 +1,5 @@
+class AddBestAnswerIdToPosts < ActiveRecord::Migration[7.1]
+  def change
+    add_reference :posts, :best_comment, foreign_key: { to_table: :comments}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_08_20_041933) do
+ActiveRecord::Schema[7.1].define(version: 2025_08_23_082052) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -69,6 +69,8 @@ ActiveRecord::Schema[7.1].define(version: 2025_08_20_041933) do
     t.bigint "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "best_comment_id"
+    t.index ["best_comment_id"], name: "index_posts_on_best_comment_id"
     t.index ["user_id"], name: "index_posts_on_user_id"
   end
 
@@ -95,5 +97,6 @@ ActiveRecord::Schema[7.1].define(version: 2025_08_20_041933) do
   add_foreign_key "comments", "users"
   add_foreign_key "post_tags", "posts"
   add_foreign_key "post_tags", "tags"
+  add_foreign_key "posts", "comments", column: "best_comment_id"
   add_foreign_key "posts", "users"
 end


### PR DESCRIPTION
## 概要
### ベストアンサー機能実装
Closes #19 
- Postテーブル内にbest_comment_idのカラムを追加し、Comment側の外部キーとして設定（has_oneでアソシエーション設定も追加）
- Commentコントローラーでset_best_commentを追加し、リクエストでPost上に選ばれたコメントをベストアンサーとして設定できる機能追加（削除は不可にしている）
- ビュー側で一覧にベストアンサーに選ぶボタンを作成、リクエストが可能になっている。ベストアンサーが設定された場合は非表示になり、選ばれたコメントがわかるよう設定

#### その他の改修
- ベストアンサーに選ばれたコメントは消せないようにCommentコントローラー側の削除処理を改修
- コメントとリプライのパーシャル内で繰り返し処理を行っていたものを外側で行うように改修