### PR TITLE
サムネイルの削除

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -50,6 +50,6 @@ class PostsController < ApplicationController
   end
 
   def post_params
-    params.require(:post).permit(:title, :content, :tag_names, :thumbnail)
+    params.require(:post).permit(:title, :content, :tag_names)
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -16,8 +16,6 @@ class Post < ApplicationRecord
     ["user", "tags"]
   end
 
-  has_one_attached :thumbnail
-
   belongs_to :user
   has_many :post_tags, dependent: :destroy
   has_many :tags, through: :post_tags

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,6 +1,4 @@
   <%= form_with model: post do |f| %>
-    <%= f.label :thumbnail, "サムネイル画像" %>
-    <%= f.file_field :thumbnail %>
     <%= f.label :title %>
     <%= f.text_field :title %>
     <%= f.label :content %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,7 +1,4 @@
 <h3>タイトル：<%= @post.title %></h3>
-<% if @post.thumbnail.attached? %>
-  <%= image_tag @post.thumbnail.variant(resize_to_limit: [200, 100]), alt: @post.title %>
-<% end %>
 <p>内容：<%= rendered_content_html(@post.content) %></p>
 <p>投稿者：<%= @post.user.name %></p>
 <% if @post.tags.any? %>


### PR DESCRIPTION
## 概要
### サムネイル削除のため以下改修
Closes #29 
- Postモデルのhas_one_attachedの削除
- ビューファイル上のthumbnailに関する表示をすべて削除