### PR TITLE
投稿のステータスを追加

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -15,7 +15,7 @@ class PostsController < ApplicationController
   end
 
   def edit
-    @post = find_post(params[:id])
+    @post = Post.find(params[:id])
   end
 
   def create
@@ -29,7 +29,7 @@ class PostsController < ApplicationController
   end
 
   def update
-    @post = find_post(params[:id])
+    @post = Post.find(params[:id])
     if @post.update(post_params)
       redirect_to post_path(@post.id)
     else
@@ -38,16 +38,23 @@ class PostsController < ApplicationController
   end
 
   def destroy
-    post = find_post(params[:id])
+    post = Post.find(params[:id])
     post.destroy
     redirect_to root_path
   end
 
-  private
-
-  def find_post(id)
-    current_user.posts.find(id)
+  def solve
+    @post = Post.find(params[:id])
+    if current_user == @post.user && @post.unsolved?
+      @post.solved!
+      current_user.increment!(:points, 2)
+      redirect_to post_path(@post), success: '解決おめでとうございます。'
+    else
+      redirect_to @post, alert: '解決済みにできません。'
+    end
   end
+
+  private
 
   def post_params
     params.require(:post).permit(:title, :content, :tag_names)

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,6 +1,7 @@
 class Post < ApplicationRecord
   validates :title, presence: true, length: { maximum: 255 }
   validates :content, presence: true, length: { maximum: 65_535 }
+  enum status: { unsolved: 0, solved: 1 }
 
   attr_accessor :tag_names
   before_save :save_tags

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,4 +1,5 @@
 <h3>タイトル：<%= @post.title %></h3>
+<p>ステータス：<%= @post.unsolved? ? '未解決' : '解決済み' %></p>
 <p>内容：<%= rendered_content_html(@post.content) %></p>
 <p>投稿者：<%= @post.user.name %></p>
 <% if @post.tags.any? %>
@@ -11,5 +12,8 @@
 <% if current_user && current_user.id == @post.user_id %>
   <%= link_to "編集", edit_post_path(@post) %>
   <%= link_to "削除", post_path(@post), data: { turbo_method: :delete, confirm: "本当に削除しますか？" } %>
+  <% if @post.unsolved? %>
+    <%= button_to "解決した", solve_post_path(@post), method: :patch, data: { confirm: 'この問題を解決済みにしますか？' } %>
+  <% end %>
 <% end%>
 <%= link_to "戻る", root_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,9 @@
 Rails.application.routes.draw do
   devise_for :users, :controllers => { :omniauth_callbacks => "users/omniauth_callbacks" }
   resources :posts, only: %i[new create edit update show destroy] do
+    member do
+      patch :solve # PATCH /posts/:id/solve
+    end
     resources :comments, only: %i[create edit destroy]
   end
   resources :comments, only: [:create] do

--- a/db/migrate/20250824115132_add_status_to_posts.rb
+++ b/db/migrate/20250824115132_add_status_to_posts.rb
@@ -1,0 +1,6 @@
+class AddStatusToPosts < ActiveRecord::Migration[7.1]
+  def change
+    add_column :posts, :status, :integer, default: 0, null: false
+    add_index :posts, :status
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_08_24_004136) do
+ActiveRecord::Schema[7.1].define(version: 2025_08_24_115132) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -70,7 +70,9 @@ ActiveRecord::Schema[7.1].define(version: 2025_08_24_004136) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "best_comment_id"
+    t.integer "status", default: 0, null: false
     t.index ["best_comment_id"], name: "index_posts_on_best_comment_id"
+    t.index ["status"], name: "index_posts_on_status"
     t.index ["user_id"], name: "index_posts_on_user_id"
   end
 


### PR DESCRIPTION
## 概要
### 投稿テーブルにステータスカラム追加
Closes #30 
- ポストのカラムを追加
- ポスト下でURL作成
- コントローラーにて解決済みステータスに更新する処理実装
- ビュー側で解決済みにできるボタンを表示
- ステータスもビュー側で見れるように修正