### PR TITLE
Markdownへのテンプレート文言追加機能実装

### DIFF
--- a/app/javascript/controllers/markdown_editor_controller.js
+++ b/app/javascript/controllers/markdown_editor_controller.js
@@ -156,4 +156,9 @@ export default class extends Controller {
     };
     return renderer;
   }
+
+  insertTemplate() {
+    const templateText = '## 問題\n\n\n\n## 試したこと\n\n\n\n## 期待する結果\n\n\n\n## 解決方法\n\n\n\n## まとめ';
+    this.easyMDE.codemirror.replaceSelection(templateText);
+  }
 }

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -10,7 +10,14 @@
     <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
       <!-- エディタ側 -->
       <div class="space-y-2">
-        <%= f.label :content, class: "block text-sm font-medium text-gray-700" %>
+        <div class="flex justify-between mb-4">
+          <%= f.label :content, class: "block text-sm font-medium text-gray-700" %>
+          <button type="button"
+                  class="px-4 py-2 font-medium bg-blue-600 text-white rounded-lg hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-colors duration-200"
+                  data-action="click->markdown-editor#insertTemplate">
+            テンプレートを挿入
+          </button>
+        </div>
         <%= f.text_area :content,
             id: "markdown-editor",
             class: "w-full",
@@ -22,7 +29,7 @@
         <label class="block text-sm font-medium text-gray-700">
           プレビュー
         </label>
-        <div id="preview-container" class="border border-gray-300 rounded-lg bg-white p-6 min-h-[500px] max-h-[600px] overflow-y-auto shadow-sm">
+        <div id="preview-container" class="border border-gray-300 rounded-lg bg-white p-6 min-h-[500px] max-h-[600px] overflow-y-auto shadow-sm mt-20">
           <p class="text-gray-500 italic">ここに内容のプレビューが表示されます</p>
         </div>
       </div>


### PR DESCRIPTION
## 概要
Closes #36 
フォーム内にボタンを追加。
ボタンを押下時にmarkdown_editor_controller内の関数でエディタ内に固定文言が入るように修正