### PR TITLE
Github連携機能の作成

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,6 +59,7 @@ gem "devise"
 gem 'omniauth'
 gem 'omniauth-github'
 gem 'omniauth-rails_csrf_protection'
+gem 'octokit'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -210,6 +210,9 @@ GEM
       rack (>= 1.2, < 4)
       snaky_hash (~> 2.0, >= 2.0.3)
       version_gem (>= 1.1.8, < 3)
+    octokit (10.0.0)
+      faraday (>= 1, < 3)
+      sawyer (~> 0.9)
     omniauth (2.1.3)
       hashie (>= 3.4.6)
       rack (>= 2.2.3)
@@ -297,6 +300,9 @@ GEM
       ffi (~> 1.12)
       logger
     rubyzip (2.4.1)
+    sawyer (0.9.2)
+      addressable (>= 2.3.5)
+      faraday (>= 0.17.3, < 3)
     securerandom (0.4.1)
     selenium-webdriver (4.34.0)
       base64 (~> 0.2)
@@ -369,6 +375,7 @@ DEPENDENCIES
   kramdown
   kramdown-parser-gfm
   nokogiri (~> 1.16)
+  octokit
   omniauth
   omniauth-github
   omniauth-rails_csrf_protection

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,12 +9,30 @@ class User < ApplicationRecord
   has_many :posts, dependent: :destroy
   has_many :comments, dependent: :destroy
 
+  def github_client
+    @github_client ||= Octokit::Client.new(access_token: github_token) if github_token.present?
+  end
+
+  def can_sync_to_github?
+    github_token.present? && github_username.present?
+  end
+
   private
 
   def self.from_omniauth(auth)
     find_or_create_by(provider: auth.provider, uid: auth.uid) do |user|
       user.email = auth.info.email
       user.name = auth.info.name
+      user.github_token = auth.credentials.token
+      user.github_username = auth.info.nickname
+    end.tap do |user|
+      # 既存ユーザーのトークンを更新
+      if user.persisted? && !user.new_record?
+        user.update!(
+          github_token: auth.credentials.token,
+          github_username: auth.info.nickname
+        )
+      end
     end
   end
 end

--- a/app/services/github_service.rb
+++ b/app/services/github_service.rb
@@ -1,8 +1,10 @@
-class GitHubService
+require 'uri'
+
+class GithubService
   def initialize(user)
     @user = user
-    @client = user.github_client
-    @repo_name = "#{user.github_username}/learning-posts"
+    @client = Octokit::Client.new(access_token: user.github_token)
+    @repo_name = "#{user.github_username}/learning-logs"
   end
 
   def can_sync?
@@ -16,11 +18,7 @@ class GitHubService
       @client.repository(@repo_name)
       true
     rescue Octokit::NotFound
-      @client.create_repository('learning-posts', {
-        description: '学習中に躓いた内容の記録です。',
-        private: false,
-        auto_init: true
-      })
+      @client.create_repository('learning-logs', description: '学習中に躓いた内容の記録です。', private: false, auto_init: true)
       true
     rescue Octokit::Error => e
       Rails.logger.error "GitHub repository setup failed: #{e.message}"
@@ -30,61 +28,138 @@ class GitHubService
 
   def sync_post(post)
     return { success: false, error: 'GitHub連携が設定されていません' } unless can_sync?
+    return { success: false, error: 'リポジトリの準備に失敗しました' } unless setup_repository
 
-    unless setup_repository
-      return { success: false, error: 'リポジトリの準備に失敗しました' }
-    end
+    content_with_github_images = sync_and_replace_image_urls(post)
+    return { success: false, error: '画像同期中にエラーが発生しました' } unless content_with_github_images
 
-    filename = "posts/#{post.created_at.strftime('%Y-%m-%d')}-#{post.title.parameterize}.md"
-    content = generate_markdown_content(post)
+    final_markdown_content = generate_markdown_content(post, content_with_github_images)
+    filename = "learning_logs/#{post.title}.md"
 
     begin
-      if post.github_sha.present?
-        response = @client.update_contents(
-          @repo_name,
-          filename,
-          "Update: #{post.title}",
-          post.github_sha,
-          content
-        )
-      else
-        response = @client.create_contents(
-          @repo_name,
-          filename,
-          "Add: #{post.title}",
-          content
-        )
-      end
+      existing_file = @client.contents(@repo_name, path: filename)
 
-      # 投稿にGitHub情報を保存（github_shaカラムが必要）
-      post.update!(
-        github_url: response.content.html_url,
-        github_sha: response.content.sha,
-        github_synced_at: Time.current
+      response = @client.update_contents(
+        @repo_name,
+        filename,
+        "Updated post: #{post.title}",
+        existing_file.sha,
+        final_markdown_content
       )
 
-      { success: true, url: response.content.html_url }
-    rescue Octokit::Error => e
-      { success: false, error: e.message }
+    rescue Octokit::NotFound
+      response = @client.create_contents(
+        @repo_name,
+        filename,
+        "Add post: #{post.title}",
+        final_markdown_content
+      )
     end
+
+    post.update!(
+      github_url: response.content.html_url,
+      github_synced_at: Time.current
+    )
+    { success: true, url: response.content.html_url }
+
+  rescue Octokit::Error => e
+    Rails.logger.error "GitHub post sync failed: #{e.message}"
+    { success: false, error: "GitHubへの投稿同期に失敗しました: #{e.message}" }
   end
 
   private
 
-  def generate_markdown_content(post)
-    content = <<~MARKDOWN
+  def sync_and_replace_image_urls(post)
+    updated_content = post.content.dup
+    regex = /!\[.*?\]\((https?:\/\/[^)]*\/rails\/active_storage\/[^)]+)\)/
+
+    post.content.scan(regex).flatten.uniq.each do |original_url|
+      blob_id = extract_blob_id_from_url(original_url)
+      next unless blob_id
+
+      blob = ActiveStorage::Blob.find_by(id: blob_id)
+      next unless blob
+
+      github_image_url = upload_image_to_github(post, blob)
+      if github_image_url
+        Rails.logger.info "URL置換: #{original_url} -> #{github_image_url}"
+        updated_content = updated_content.gsub(original_url, github_image_url)
+      else
+        Rails.logger.error "GitHubへの画像アップロードに失敗しました: #{blob.filename}"
+        return nil
+      end
+    end
+
+    updated_content
+  end
+
+  def upload_image_to_github(post, blob)
+    return nil unless blob
+
+    begin
+      image_data = blob.download
+
+      timestamp = Time.current.strftime('%Y%m%d%H%M%S')
+      original_filename = blob.filename.to_s
+      extension = File.extname(original_filename)
+      basename = File.basename(original_filename, extension)
+      safe_basename = I18n.transliterate(basename).gsub(/[^a-zA-Z0-9\-]/, '_').downcase
+      safe_filename = "#{timestamp}_#{safe_basename}#{extension}"
+      github_path = "learning_logs/images/#{post.id}/#{safe_filename}"
+
+      response = @client.create_contents(
+        @repo_name,
+        github_path,
+        "Add image: #{original_filename}",
+        image_data
+      )
+      return response.content.download_url
+
+    rescue Octokit::Conflict
+      encoded_path = ["learning_logs", "images", post.id.to_s, safe_filename].map do |s|
+        URI.encode_www_form_component(s)
+      end.join('/')
+      existing_url = "https://raw.githubusercontent.com/#{@repo_name}/main/#{encoded_path}"
+      Rails.logger.warn "画像は既に存在します: #{existing_url}"
+      return existing_url
+
+    rescue Octokit::Error => e
+      Rails.logger.error "❌ GitHub画像アップロードエラー: #{e.message}"
+      return nil
+    end
+  end
+
+  def extract_blob_id_from_url(url)
+    return nil unless url.include?('/rails/active_storage/')
+
+    signed_id_patterns = [
+      %r{/blobs/redirect/([^/]+)},
+      %r{/blobs/proxy/([^/]+)},
+      %r{/blobs/([^/]+)}
+    ]
+
+    signed_id_patterns.each do |pattern|
+      if match = url.match(pattern)
+        signed_id = match.captures.first.split('?').first
+        begin
+          return ActiveStorage.verifier.verify(signed_id, purpose: :blob_id)
+        rescue ActiveSupport::MessageVerifier::InvalidSignature
+          next
+        end
+      end
+    end
+    Rails.logger.error "Blob IDの抽出に失敗しました: #{url}"
+    nil
+  end
+
+  def generate_markdown_content(post, content)
+    <<~MARKDOWN
       # #{post.title}
 
       **作成日**: #{post.created_at.strftime('%Y年%m月%d日')}
       **最終更新**: #{post.updated_at.strftime('%Y年%m月%d日')}
 
-      #{post.content}
-
-      ---
-
-      *この投稿はわかんにゃいから自動同期されました*
+      #{content}
     MARKDOWN
-
-    Base64.encode64(content)
   end
 end

--- a/app/services/github_service.rb
+++ b/app/services/github_service.rb
@@ -1,0 +1,90 @@
+class GitHubService
+  def initialize(user)
+    @user = user
+    @client = user.github_client
+    @repo_name = "#{user.github_username}/learning-posts"
+  end
+
+  def can_sync?
+    @user.can_sync_to_github? && @client.present?
+  end
+
+  def setup_repository
+    return false unless can_sync?
+
+    begin
+      @client.repository(@repo_name)
+      true
+    rescue Octokit::NotFound
+      @client.create_repository('learning-posts', {
+        description: '学習中に躓いた内容の記録です。',
+        private: false,
+        auto_init: true
+      })
+      true
+    rescue Octokit::Error => e
+      Rails.logger.error "GitHub repository setup failed: #{e.message}"
+      false
+    end
+  end
+
+  def sync_post(post)
+    return { success: false, error: 'GitHub連携が設定されていません' } unless can_sync?
+
+    unless setup_repository
+      return { success: false, error: 'リポジトリの準備に失敗しました' }
+    end
+
+    filename = "posts/#{post.created_at.strftime('%Y-%m-%d')}-#{post.title.parameterize}.md"
+    content = generate_markdown_content(post)
+
+    begin
+      if post.github_sha.present?
+        response = @client.update_contents(
+          @repo_name,
+          filename,
+          "Update: #{post.title}",
+          post.github_sha,
+          content
+        )
+      else
+        response = @client.create_contents(
+          @repo_name,
+          filename,
+          "Add: #{post.title}",
+          content
+        )
+      end
+
+      # 投稿にGitHub情報を保存（github_shaカラムが必要）
+      post.update!(
+        github_url: response.content.html_url,
+        github_sha: response.content.sha,
+        github_synced_at: Time.current
+      )
+
+      { success: true, url: response.content.html_url }
+    rescue Octokit::Error => e
+      { success: false, error: e.message }
+    end
+  end
+
+  private
+
+  def generate_markdown_content(post)
+    content = <<~MARKDOWN
+      # #{post.title}
+
+      **作成日**: #{post.created_at.strftime('%Y年%m月%d日')}
+      **最終更新**: #{post.updated_at.strftime('%Y年%m月%d日')}
+
+      #{post.content}
+
+      ---
+
+      *この投稿はわかんにゃいから自動同期されました*
+    MARKDOWN
+
+    Base64.encode64(content)
+  end
+end

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,9 +1,21 @@
 <h3>タイトル：<%= @post.title %></h3>
+<% if current_user.can_sync_to_github? && current_user.id == @post.user_id %>
+  <%= button_to "GitHubに同期", sync_to_github_post_path(@post), method: :patch, class: "btn btn-outline-primary btn-sm" %>
+<% end %>
 <p>ステータス：<%= @post.unsolved? ? '未解決' : '解決済み' %></p>
 <div class="prose">
   <p>内容：<%= rendered_content_html(@post.content) %></p>
 </div>
 <p>投稿者：<%= @post.user.name %></p>
+<% if @post.github_url.present? && current_user.id == @post.user_id %>
+  <div class="mt-3">
+    <small class="text-muted">
+      <i class="fab fa-github"></i>
+      <%= link_to "GitHubで見る", @post.github_url, target: "_blank" %>
+      （最終同期: <%= @post.github_synced_at.strftime('%Y/%m/%d %H:%M') %>）
+    </small>
+  </div>
+<% end %>
 <% if @post.tags.any? %>
   <p>タグ：<%= @post.tags.map(&:name).join(', ') %></p>
 <% end %>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -310,5 +310,5 @@ Devise.setup do |config|
   # When set to false, does not sign a user in automatically after their password is
   # changed. Defaults to true, so a user is signed in automatically after changing a password.
   # config.sign_in_after_change_password = true
-  config.omniauth :github, ENV['GITHUB_ID'], ENV['GITHUB_SECRET'], scope: 'user,public_repo'
+  config.omniauth :github, ENV['GITHUB_ID'], ENV['GITHUB_SECRET'], scope: 'user,public_repo,repo'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,8 @@ Rails.application.routes.draw do
   devise_for :users, :controllers => { :omniauth_callbacks => "users/omniauth_callbacks" }
   resources :posts, only: %i[new create edit update show destroy] do
     member do
-      patch :solve # PATCH /posts/:id/solve
+      patch :solve
+      patch :sync_to_github
     end
     resources :comments, only: %i[create edit destroy]
   end

--- a/db/migrate/20250831015856_add_github_fields_to_users.rb
+++ b/db/migrate/20250831015856_add_github_fields_to_users.rb
@@ -1,0 +1,6 @@
+class AddGithubFieldsToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :github_token, :string
+    add_column :users, :github_username, :string
+  end
+end

--- a/db/migrate/20250901063459_add_github_fields_to_posts.rb
+++ b/db/migrate/20250901063459_add_github_fields_to_posts.rb
@@ -1,0 +1,8 @@
+class AddGithubFieldsToPosts < ActiveRecord::Migration[7.1]
+  def change
+    add_column :posts, :github_url, :string
+    add_column :posts, :github_sha, :string
+    add_column :posts, :github_synced_at, :datetime
+    add_column :posts, :auto_sync_github, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_08_31_015856) do
+ActiveRecord::Schema[7.1].define(version: 2025_09_01_063459) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -71,6 +71,10 @@ ActiveRecord::Schema[7.1].define(version: 2025_08_31_015856) do
     t.datetime "updated_at", null: false
     t.bigint "best_comment_id"
     t.integer "status", default: 0, null: false
+    t.string "github_url"
+    t.string "github_sha"
+    t.datetime "github_synced_at"
+    t.boolean "auto_sync_github"
     t.index ["best_comment_id"], name: "index_posts_on_best_comment_id"
     t.index ["status"], name: "index_posts_on_status"
     t.index ["user_id"], name: "index_posts_on_user_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_08_24_115132) do
+ActiveRecord::Schema[7.1].define(version: 2025_08_31_015856) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -91,6 +91,8 @@ ActiveRecord::Schema[7.1].define(version: 2025_08_24_115132) do
     t.string "provider"
     t.string "uid"
     t.integer "points", default: 0, null: false
+    t.string "github_token"
+    t.string "github_username"
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"


### PR DESCRIPTION
## 概要
### Github連携機能作成
Closes #41  

- ユーザーテーブルへのカラム追加(githubの名前、トークンの取得のため)
- Octokitの導入
- レポジトリの作成/更新機能追加
- 画像アップロード機能追加