### PR TITLE
詳細画面の記事内容のマークダウンCSSの変更

### DIFF
--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -9,7 +9,18 @@
     </div>
 
     <div>
-      <p class="mt-4 text-terminal-text">内容：<%= rendered_content_html(@post.content) %></p>
+      <div class="mt-4 text-terminal-text mb-2">内容：</div>
+      <article
+        class="prose prose-invert max-w-none
+              prose-headings:text-terminal-accent
+              prose-a:text-terminal-accent
+              prose-strong:text-terminal-text
+              prose-p:text-terminal-text
+              prose-hr:border-terminal-border
+              prose-pre:bg-terminal-input prose-pre:text-terminal-text
+              prose-code:text-terminal-text">
+        <%= rendered_content_html(@post.content) %>
+      </article>
     </div>
 
     <div class="mt-6 border-t border-terminal-border pt-4 text-sm text-gray-400">


### PR DESCRIPTION
## 概要
### 記事内容表示のHTML&CSSの変更
Closes #67 
- 原因
  - 記事の内容を全てpタグで囲んでしまっていたためバグ発生、またtailwindの影響もありそれぞれのタグ本来のスタイルとずれがあった。
- 対応
  - p タグ外で内容表示
  - 別タグでproseを指定しCSS適用