### PR TITLE
Github連携機能の修正

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,7 @@ gem 'omniauth'
 gem 'omniauth-github'
 gem 'omniauth-rails_csrf_protection'
 gem 'octokit'
+gem 'jwt'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -410,6 +410,7 @@ DEPENDENCIES
   image_processing (~> 1.2)
   importmap-rails
   jbuilder
+  jwt
   kaminari
   kramdown
   kramdown-parser-gfm

--- a/app/controllers/github/repos_controller.rb
+++ b/app/controllers/github/repos_controller.rb
@@ -1,0 +1,31 @@
+class Github::ReposController < ApplicationController
+  before_action :authenticate_user!
+
+  def index
+    unless current_user.github_app_installation_id.present?
+      redirect_to post_path(params[:return_to] || current_user.posts.first),
+        alert: "まず GitHub App をインストールしてください。"
+      return
+    end
+
+    client = GithubApp.installation_client(current_user.github_app_installation_id)
+
+    repos_resp = client.list_app_installation_repositories
+    @repos = repos_resp.repositories
+    @return_to = params[:return_to]
+  rescue Octokit::Error => e
+    redirect_to root_path, alert: "レポジトリ一覧の取得に失敗しました: #{e.message}"
+  end
+
+  def create
+    repo_full_name = params[:repo_full_name]
+    branch = params[:branch].presence
+    if repo_full_name.blank?
+      redirect_to github_repos_path, alert: "レポジトリを選択してください。"
+      return
+    end
+
+    current_user.update!(github_repo_full_name: repo_full_name, github_branch: branch)
+    redirect_to(params[:return_to].presence || root_path, notice: "同期先を設定しました。")
+  end
+end

--- a/app/controllers/github/repos_controller.rb
+++ b/app/controllers/github/repos_controller.rb
@@ -2,30 +2,35 @@ class Github::ReposController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    unless current_user.github_app_installation_id.present?
-      redirect_to post_path(params[:return_to] || current_user.posts.first),
-        alert: "まず GitHub App をインストールしてください。"
-      return
+    result = GithubService.new(current_user).list_repos
+    if result[:success]
+      @repos     = result[:repos]
+      @return_to = params[:return_to]
+    else
+      redirect_to safe_return_path, alert: result[:error]
     end
-
-    client = GithubApp.installation_client(current_user.github_app_installation_id)
-
-    repos_resp = client.list_app_installation_repositories
-    @repos = repos_resp.repositories
-    @return_to = params[:return_to]
-  rescue Octokit::Error => e
-    redirect_to root_path, alert: "レポジトリ一覧の取得に失敗しました: #{e.message}"
   end
 
   def create
     repo_full_name = params[:repo_full_name]
-    branch = params[:branch].presence
+    branch         = params[:branch].presence
+
     if repo_full_name.blank?
-      redirect_to github_repos_path, alert: "レポジトリを選択してください。"
-      return
+      redirect_to github_repos_path(return_to: params[:return_to]), alert: "レポジトリを選択してください。" and return
     end
 
-    current_user.update!(github_repo_full_name: repo_full_name, github_branch: branch)
-    redirect_to(params[:return_to].presence || root_path, notice: "同期先を設定しました。")
+    result = GithubService.new(current_user).set_repo!(full_name: repo_full_name, branch: branch)
+    if result[:success]
+      redirect_to(params[:return_to].presence || root_path, notice: "同期先を設定しました。")
+    else
+      redirect_to github_repos_path(return_to: params[:return_to]), alert: result[:error]
+    end
+  end
+
+  private
+
+  def safe_return_path
+    rt = params[:return_to].to_s
+    rt.present? && rt.start_with?("/") ? rt : (current_user.posts.first ? post_path(current_user.posts.first) : root_path)
   end
 end

--- a/app/controllers/github/setup_controller.rb
+++ b/app/controllers/github/setup_controller.rb
@@ -3,12 +3,16 @@ class Github::SetupController < ApplicationController
 
   def update
     installation_id = params[:installation_id]
-    if installation_id.present?
-      current_user.update!(github_app_installation_id: installation_id)
+    unless installation_id.present?
+      redirect_to root_path, alert: "installation_id が取得できませんでした。" and return
+    end
+
+    result = GithubService.new(current_user).link_installation!(installation_id)
+    if result[:success]
       redirect_to github_repos_path(return_to: params[:return_to]),
         notice: "GitHub App を連携しました。同期先レポジトリを選んでください。"
     else
-      redirect_to root_path, alert: "installation_id が取得できませんでした。"
+      redirect_to root_path, alert: result[:error]
     end
   end
 end

--- a/app/controllers/github/setup_controller.rb
+++ b/app/controllers/github/setup_controller.rb
@@ -1,0 +1,14 @@
+class Github::SetupController < ApplicationController
+  before_action :authenticate_user!
+
+  def update
+    installation_id = params[:installation_id]
+    if installation_id.present?
+      current_user.update!(github_app_installation_id: installation_id)
+      redirect_to github_repos_path(return_to: params[:return_to]),
+        notice: "GitHub App を連携しました。同期先レポジトリを選んでください。"
+    else
+      redirect_to root_path, alert: "installation_id が取得できませんでした。"
+    end
+  end
+end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,15 +1,14 @@
 class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
-  skip_before_action :verify_authenticity_token, only: :github
+  skip_before_action :verify_authenticity_token, only: :github_app
 
-  def github
-    # You need to implement the method below in your model (e.g. app/models/user.rb)
-    @user = User.from_omniauth(request.env["omniauth.auth"])
-
+  def github_app
+    auth = request.env["omniauth.auth"]
+    @user = User.from_github_app_oauth(auth)
     if @user.persisted?
-      sign_in_and_redirect @user, event: :authentication # this will throw if @user is not activated
+      sign_in_and_redirect @user, event: :authentication
       set_flash_message!(:notice, :success, kind: "Github") if is_navigational_format?
     else
-      session["devise.github_data"] = request.env["omniauth.auth"].except(:extra) # Removing extra as it can overflow some session stores
+      session["devise.github_app_data"] = auth.except(:extra)
       redirect_to new_user_registration_url
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,12 +11,8 @@ class User < ApplicationRecord
   has_one :cat, dependent: :destroy
   after_create :assign_random_cat
 
-  def github_client
-    # @github_client ||= Octokit::Client.new(access_token: github_token) if github_token.present?
-  end
-
   def can_sync_to_github?
-    github_installation_id.present? && github_repo_full_name.present?
+    github_app_installation_id.present? && github_repo_full_name.present?
   end
 
   private

--- a/app/services/github_app.rb
+++ b/app/services/github_app.rb
@@ -1,0 +1,22 @@
+class GithubApp
+  class InstallationMissing < StandardError; end
+
+  def self.jwt
+    private_key = OpenSSL::PKey::RSA.new(ENV.fetch("GITHUB_APP_PRIVATE_KEY").gsub("\\n", "\n"))
+    payload = {
+      iat: Time.now.to_i - 60,
+      exp: Time.now.to_i + 9*60,
+      iss: ENV.fetch("GITHUB_APP_ID").to_i
+    }
+    JWT.encode(payload, private_key, "RS256")
+  end
+
+  def self.installation_client(installation_id)
+    app_client = Octokit::Client.new(bearer_token: jwt)
+    app_client.installation(installation_id)
+    token = app_client.create_app_installation_access_token(installation_id)[:token]
+    Octokit::Client.new(access_token: token)
+  rescue Octokit::NotFound
+    return nil
+  end
+end

--- a/app/services/github_app.rb
+++ b/app/services/github_app.rb
@@ -1,6 +1,7 @@
 class GithubApp
   class InstallationMissing < StandardError; end
 
+  # 鍵作成
   def self.jwt
     private_key = OpenSSL::PKey::RSA.new(ENV.fetch("GITHUB_APP_PRIVATE_KEY").gsub("\\n", "\n"))
     payload = {
@@ -11,12 +12,13 @@ class GithubApp
     JWT.encode(payload, private_key, "RS256")
   end
 
+  # クライアント取得
   def self.installation_client(installation_id)
     app_client = Octokit::Client.new(bearer_token: jwt)
-    app_client.installation(installation_id)
-    token = app_client.create_app_installation_access_token(installation_id)[:token]
+    iid   = installation_id.to_i
+    token = app_client.create_app_installation_access_token(iid)[:token]
     Octokit::Client.new(access_token: token)
   rescue Octokit::NotFound
-    return nil
+    nil
   end
 end

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -2,7 +2,7 @@
   <h2 class="text-3xl font-bold mb-6 text-terminal-accent">ログイン</h2>
   <div class="bg-terminal-input p-8 border border-terminal-border rounded-lg shadow-sm text-center max-w-sm w-full">
     <p class="text-terminal-text mb-4">GitHubアカウントでログインしてください</p>
-    <%= button_to "GitHubでログイン", user_github_omniauth_authorize_path,
+    <%= button_to "GitHubでログイン", user_github_app_omniauth_authorize_path,
                   class: "w-full py-2 bg-terminal-accent text-terminal-bg font-bold rounded-lg hover:bg-terminal-accent/80 transition-colors duration-200",
                   data: { turbo: false } %>
   </div>

--- a/app/views/github/repos/index.html.erb
+++ b/app/views/github/repos/index.html.erb
@@ -1,0 +1,60 @@
+<div class="container mx-auto px-4 py-8 max-w-7xl">
+  <div class="bg-terminal-input border border-terminal-border rounded-lg p-6 shadow-sm">
+    <h2 class="text-xl font-bold text-terminal-text mb-6">同期先レポジトリを選択</h2>
+
+    <%= form_with url: github_repos_path, method: :post, local: true do %>
+      <input type="hidden" name="return_to" value="<%= @return_to %>">
+
+      <div class="mb-6">
+        <label class="block text-sm font-medium text-terminal-text mb-2">レポジトリ</label>
+        <div class="space-y-2 max-h-[60vh] overflow-auto border border-terminal-border rounded-lg p-3 bg-terminal-input">
+          <% @repos.each do |r| %>
+            <label class="flex items-center justify-between gap-3 w-full px-3 py-2 border border-terminal-border/60 rounded-lg bg-terminal-input hover:bg-terminal-bg/40 cursor-pointer transition-colors duration-150">
+              <span class="flex items-center gap-3">
+                <input
+                  type="radio"
+                  name="repo_full_name"
+                  value="<%= r.full_name %>"
+                  class="accent-terminal-accent"
+                  <%= 'checked' if current_user&.github_repo_full_name == r.full_name %>
+                >
+                <span class="text-terminal-text font-medium"><%= r.full_name %></span>
+              </span>
+              <% if r.private %>
+                <span class="text-xs px-2 py-0.5 rounded bg-terminal-bg/40 text-gray-400 border border-terminal-border/60">
+                  private
+                </span>
+              <% end %>
+            </label>
+          <% end %>
+          <% if @repos.blank? %>
+            <p class="text-sm text-gray-400 px-1 py-2">インストール済みのレポジトリが見つかりません。</p>
+          <% end %>
+        </div>
+      </div>
+
+      <div class="mb-6">
+        <label class="block text-sm font-medium text-terminal-text mb-2">
+          ブランチ（省略可: 既定ブランチ使用）
+        </label>
+        <input
+          type="text"
+          name="branch"
+          value="<%= current_user&.github_branch %>"
+          placeholder="例: main"
+          class="w-full px-3 py-2 border border-terminal-border bg-terminal-input text-terminal-text rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-terminal-accent/50 focus:border-terminal-accent"
+        >
+      </div>
+
+      <div class="flex justify-end gap-3">
+        <%= link_to "キャンセル", (@return_to.presence || root_path),
+              class: "px-4 py-2 border border-terminal-border text-terminal-text rounded-lg hover:bg-terminal-bg/40 transition-colors duration-200" %>
+        <button
+          type="submit"
+          class="px-6 py-2 bg-terminal-accent text-terminal-bg font-medium rounded-lg hover:bg-terminal-accent/80 focus:outline-none focus:ring-2 focus:ring-terminal-accent/50 focus:ring-offset-2 transition-colors duration-200">
+          保存
+        </button>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -42,8 +42,27 @@
         <% end%>
       </div>
 
-      <% if current_user.can_sync_to_github? && current_user.id == @post.user_id %>
-        <%= button_to "GitHubに同期", sync_to_github_post_path(@post), method: :patch, class: "btn-terminal" %>
+      <% if current_user && current_user.id == @post.user_id %>
+        <% if current_user.github_app_installation_id.blank? %>
+          <% install_url = "https://github.com/apps/#{ENV['GITHUB_APP_SLUG']}/installations/new" %>
+          <%= link_to "GitHub App をインストール", install_url,
+                class: "btn-terminal-accent", data: { turbo: false } %>
+
+        <% elsif current_user.github_repo_full_name.blank? %>
+          <%= link_to "同期先を選ぶ", github_repos_path(return_to: post_path(@post)),
+                class: "btn-terminal-accent" %>
+
+        <% else %>
+          <div class="flex items-center gap-2">
+            <%= button_to "GitHubに同期", sync_to_github_post_path(@post),
+                  method: :patch, class: "btn-terminal" %>
+            <span class="text-xs text-gray-400">
+              同期先: <%= current_user.github_repo_full_name %>
+              <% if current_user.github_branch.present? %>(<%= current_user.github_branch %>)<% end %>
+              · <%= link_to "変更", github_repos_path(return_to: post_path(@post)), class: "underline" %>
+            </span>
+          </div>
+        <% end %>
       <% end %>
     </div>
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -310,5 +310,8 @@ Devise.setup do |config|
   # When set to false, does not sign a user in automatically after their password is
   # changed. Defaults to true, so a user is signed in automatically after changing a password.
   # config.sign_in_after_change_password = true
-  config.omniauth :github, ENV['GITHUB_ID'], ENV['GITHUB_SECRET'], scope: 'user,public_repo,repo'
+  # config.omniauth :github, ENV['GITHUB_ID'], ENV['GITHUB_SECRET'], scope: 'user,public_repo,repo'
+  config.omniauth :github, ENV['GITHUB_APP_CLIENT_ID'], ENV['GITHUB_APP_CLIENT_SECRET'],
+                scope: 'read:user,user:email',
+                name:  :github_app
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,11 @@ Rails.application.routes.draw do
     delete 'sign_out', to: 'devise/sessions#destroy', as: :destroy_user_session
   end
 
+  get "/github/setup", to: "github/setup#update"
+  namespace :github do
+    resources :repos, only: [:index, :create]
+  end
+
   root 'posts#index'
   get 'posts/my_posts', to: 'posts#my_posts'
   resources :posts, only: %i[new create edit update show destroy] do

--- a/db/migrate/20250915032533_add_github_app_fields_to_users.rb
+++ b/db/migrate/20250915032533_add_github_app_fields_to_users.rb
@@ -1,11 +1,11 @@
 class AddGithubAppFieldsToUsers < ActiveRecord::Migration[7.1]
   def change
-    add_column :users, :github_installation_id, :bigint
+    add_column :users, :github_app_installation_id, :bigint
     add_column :users, :github_repo_full_name, :string
     add_column :users, :github_app_user_token, :text
     add_column :users, :github_branch, :string, default: "main"
 
     add_index :users, [:provider, :uid], unique: true
-    add_index :users, :github_installation_id
+    add_index :users, :github_app_installation_id
   end
 end

--- a/db/migrate/20250915032533_add_github_app_fields_to_users.rb
+++ b/db/migrate/20250915032533_add_github_app_fields_to_users.rb
@@ -1,0 +1,11 @@
+class AddGithubAppFieldsToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :github_installation_id, :bigint
+    add_column :users, :github_repo_full_name, :string
+    add_column :users, :github_app_user_token, :text
+    add_column :users, :github_branch, :string, default: "main"
+
+    add_index :users, [:provider, :uid], unique: true
+    add_index :users, :github_installation_id
+  end
+end

--- a/db/migrate/20250915032925_remove_github_token_from_users.rb
+++ b/db/migrate/20250915032925_remove_github_token_from_users.rb
@@ -1,0 +1,10 @@
+class RemoveGithubTokenFromUsers < ActiveRecord::Migration[7.1]
+  def up
+    execute "UPDATE users SET github_token = NULL" rescue nil
+    remove_column :users, :github_token, :string
+  end
+
+  def down
+    add_column :users, :github_token, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_09_06_084602) do
+ActiveRecord::Schema[7.1].define(version: 2025_09_15_032925) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -103,8 +103,13 @@ ActiveRecord::Schema[7.1].define(version: 2025_09_06_084602) do
     t.string "provider"
     t.string "uid"
     t.integer "points", default: 0, null: false
-    t.string "github_token"
     t.string "github_username"
+    t.bigint "github_installation_id"
+    t.string "github_repo_full_name"
+    t.text "github_app_user_token"
+    t.string "github_branch", default: "main"
+    t.index ["github_installation_id"], name: "index_users_on_github_installation_id"
+    t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -104,11 +104,11 @@ ActiveRecord::Schema[7.1].define(version: 2025_09_15_032925) do
     t.string "uid"
     t.integer "points", default: 0, null: false
     t.string "github_username"
-    t.bigint "github_installation_id"
+    t.bigint "github_app_installation_id"
     t.string "github_repo_full_name"
     t.text "github_app_user_token"
     t.string "github_branch", default: "main"
-    t.index ["github_installation_id"], name: "index_users_on_github_installation_id"
+    t.index ["github_app_installation_id"], name: "index_users_on_github_app_installation_id"
     t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true
   end
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -3,9 +3,11 @@ FactoryBot.define do
     name { "Test User" }
     sequence(:email) { |n| "test-#{n}-#{SecureRandom.hex(4)}@example.com" }
 
-    trait :github_authenticated do
-      github_token { "mock_github_token" }
-      github_username { "test_user_github" }
+    trait :with_github_app do
+      github_app_installation_id { 123456789 }
+      github_repo_full_name      { "someone/learning-logs" }
+      github_branch              { "main" }
+      github_username            { "test_user_github" }
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,27 +1,30 @@
-
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  describe 'UserとCatのアソシエーション確認' do
-    # 💡 ユーザーが作成されたときに、catも自動で作成されるか？
-    it 'ひもづく猫を自動的に作成する' do
+  describe 'UserとCatのアソシエーション' do
+    it 'ユーザー作成時にCatが自動作成される' do
       user = create(:user)
       expect(user.cat).to be_present
     end
   end
 
-  describe 'UserのGithub連携' do
-    context 'ユーザーがGithubトークンを保持している' do
-      let(:user) { create(:user, github_token: 'test_token') }
-      it 'Octokitのクライアントが存在する' do
-        expect(user.github_client).to be_an_instance_of(Octokit::Client)
+  describe 'GitHub App 連携判定' do
+    context 'インストールIDと保存先リポが揃っている' do
+      it 'can_sync_to_github? が true' do
+        user = create(:user, :with_github_app)
+        expect(user.can_sync_to_github?).to eq(true)
       end
     end
 
-    context 'Githubトークンがない' do
-      let(:user) { create(:user, github_token: nil) }
-      it 'Githubクライアントはない' do
-        expect(user.github_client).to be_nil
+    context '不足している時' do
+      it 'インストールIDが無ければ false' do
+        user = create(:user, github_repo_full_name: 'someone/learning-logs')
+        expect(user.can_sync_to_github?).to eq(false)
+      end
+
+      it '保存先リポが無ければ false' do
+        user = create(:user, github_app_installation_id: 123)
+        expect(user.can_sync_to_github?).to eq(false)
       end
     end
   end

--- a/spec/services/github_service_spec.rb
+++ b/spec/services/github_service_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe GithubService do
         { content: { html_url: "https://github.com/owner/repo/blob/main/wakannyai_posts/title.md" } }.with_indifferent_access
       )
 
-      result = service.sync_post(post_rec)
+      result = service.sync_post!(post_rec)
 
       expect(result[:success]).to be true
       expect(result[:url]).to include("github.com/owner/repo")
@@ -39,17 +39,16 @@ RSpec.describe GithubService do
         { content: { html_url: "https://github.com/owner/repo/blob/main/wakannyai_posts/title.md" } }.with_indifferent_access
       )
 
-      result = service.sync_post(post_rec)
+      result = service.sync_post!(post_rec)
       expect(result[:success]).to be true
     end
   end
 
   context "異常系" do
     it "アンインストール（InstallationMissing）ならフレンドリーに失敗" do
-      allow(GithubApp).to receive(:installation_client).with(123)
-        .and_raise(GithubApp::InstallationMissing)
+      allow(GithubApp).to receive(:installation_client).with(123).and_return(nil)
 
-      result = service.sync_post(post_rec)
+      result = service.sync_post!(post_rec)
       expect(result[:success]).to be false
       expect(result[:error]).to match(/アンインストール|再接続/)
     end
@@ -64,7 +63,7 @@ RSpec.describe GithubService do
 
       allow(client).to receive(:create_contents).and_raise(Octokit::Forbidden)
 
-      result = described_class.new(user).sync_post(post_rec)
+      result = described_class.new(user).sync_post!(post_rec)
 
       expect(result[:success]).to be(false)
       expect(result[:error]).to include("権限")
@@ -88,7 +87,7 @@ RSpec.describe GithubService do
 
       allow(client).to receive(:create_contents).and_raise(Octokit::NotFound)
 
-      result = GithubService.new(user).sync_post(post_rec)
+      result = GithubService.new(user).sync_post!(post_rec)
 
       expect(result[:success]).to be(false)
       expect(result[:error]).to match(/リポジトリが見つかりません|Not\s*Found/i)

--- a/spec/services/github_service_spec.rb
+++ b/spec/services/github_service_spec.rb
@@ -1,0 +1,97 @@
+require "ostruct"
+require "rails_helper"
+
+RSpec.describe GithubService do
+  let(:user) do
+    build(:user,
+      name: "U",
+      email: "u@example.com",
+      github_app_installation_id: 123,
+      github_repo_full_name: "owner/repo",
+      github_branch: "main"
+    )
+  end
+
+  let(:service) { described_class.new(user) }
+  let(:client)  { double("Octokit::Client") }
+  let(:post_rec) { create(:post, user: user, title: "タイトル!!", content: "本文です", created_at: Time.current, updated_at: Time.current) }
+
+  before do
+    allow(GithubApp).to receive(:installation_client).with(123).and_return(client)
+  end
+
+  context "正常系" do
+    it "新規ファイルを作成して URL を返す" do
+      allow(client).to receive(:contents).and_raise(Octokit::NotFound)
+      allow(client).to receive(:create_contents).and_return(
+        { content: { html_url: "https://github.com/owner/repo/blob/main/wakannyai_posts/title.md" } }.with_indifferent_access
+      )
+
+      result = service.sync_post(post_rec)
+
+      expect(result[:success]).to be true
+      expect(result[:url]).to include("github.com/owner/repo")
+    end
+
+    it "既存ファイルを更新して URL を返す" do
+      allow(client).to receive(:contents).and_return(OpenStruct.new(sha: "abc123"))
+      allow(client).to receive(:update_contents).and_return(
+        { content: { html_url: "https://github.com/owner/repo/blob/main/wakannyai_posts/title.md" } }.with_indifferent_access
+      )
+
+      result = service.sync_post(post_rec)
+      expect(result[:success]).to be true
+    end
+  end
+
+  context "異常系" do
+    it "アンインストール（InstallationMissing）ならフレンドリーに失敗" do
+      allow(GithubApp).to receive(:installation_client).with(123)
+        .and_raise(GithubApp::InstallationMissing)
+
+      result = service.sync_post(post_rec)
+      expect(result[:success]).to be false
+      expect(result[:error]).to match(/アンインストール|再接続/)
+    end
+
+    it "Forbidden/Unauthorized なら権限不足のメッセージ" do
+      client = instance_double(Octokit::Client)
+
+      allow(GithubApp).to receive(:installation_client).with(123).and_return(client)
+      allow(client).to receive(:repo).with("owner/repo")
+        .and_return(OpenStruct.new(default_branch: "main"))
+      allow(client).to receive(:contents).and_return(nil)
+
+      allow(client).to receive(:create_contents).and_raise(Octokit::Forbidden)
+
+      result = described_class.new(user).sync_post(post_rec)
+
+      expect(result[:success]).to be(false)
+      expect(result[:error]).to include("権限")
+    end
+
+    it "NotFound（リポジトリなし）" do
+      user = create(:user,
+        name: "U", email: "u@example.com",
+        github_app_installation_id: 123,
+        github_repo_full_name: "owner/repo",
+        github_branch: "main"
+      )
+      post_rec = create(:post, user: user, title: "タイトル!!", content: "本文です",
+                        created_at: Time.current, updated_at: Time.current)
+
+      client = instance_double(Octokit::Client)
+
+      allow(GithubApp).to receive(:installation_client).with(123).and_return(client)
+
+      allow(client).to receive(:contents).and_return(nil)
+
+      allow(client).to receive(:create_contents).and_raise(Octokit::NotFound)
+
+      result = GithubService.new(user).sync_post(post_rec)
+
+      expect(result[:success]).to be(false)
+      expect(result[:error]).to match(/リポジトリが見つかりません|Not\s*Found/i)
+    end
+  end
+end

--- a/spec/system/authorization_spec.rb
+++ b/spec/system/authorization_spec.rb
@@ -2,7 +2,7 @@
 require "rails_helper"
 
 RSpec.describe "Authorization", type: :system, js: true do
-  let(:me)    { create(:user, :github_authenticated, name: "Me") }
+  let(:me)    { create(:user, :with_github_app, name: "Me") }
   let(:other) { create(:user, name: "Other") }
 
   it "他人の投稿では編集/削除/解決ボタンが出ない" do

--- a/spec/system/comments_spec.rb
+++ b/spec/system/comments_spec.rb
@@ -2,7 +2,7 @@
 require "rails_helper"
 
 RSpec.describe "Comments", type: :system, js: true do
-  let(:author) { create(:user, :github_authenticated, name: "著者") }
+  let(:author) { create(:user, :with_github_app, name: "著者") }
   let(:answer) { create(:user, name: "回答者") }
   let(:post_)  { create(:post, user: author, title: "Q", content: "本文") }
 

--- a/spec/system/github_sync_spec.rb
+++ b/spec/system/github_sync_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe "GitHub同期", type: :system, js: true do
+  let(:author) { create(:user, name: "Test User", email: "u@example.com") }
+
+  before do
+    login_as(author, scope: :user)
+  end
+
+  context "同期成功" do
+    it "同期成功でフラッシュ表示" do
+      # App連携が整っているユーザーにする
+      author.update!(
+        github_app_installation_id: 123,
+        github_repo_full_name: "owner/repo",
+        github_branch: "main"
+      )
+      post = create(:post, user: author, title: "同期テスト", content: "本文", created_at: Time.current, updated_at: Time.current)
+
+      # Octokitクライアントのスタブ
+      client = instance_double(Octokit::Client)
+      allow(GithubApp).to receive(:installation_client).with(123).and_return(client)
+
+      # 新規作成フローに入るため contents は nil
+      allow(client).to receive(:contents).with("owner/repo", hash_including(path: /wakannyai_posts/)).and_return(nil)
+
+      # create_contents が正しく呼ばれ、URLを返す
+      allow(client).to receive(:create_contents)
+        .and_return({ content: { html_url: "https://github.com/owner/repo/blob/main/wakannyai_posts/post.md" } })
+
+      visit post_path(post)
+      click_button "GitHubに同期"
+
+      expect(page).to have_current_path(post_path(post), ignore_query: true, wait: 5)
+      expect(page).to have_content("GitHubに同期しました").or have_content("同期しました")
+      # show にリンク表示されていればより安心
+      expect(page).to have_link("GitHubで見る")
+    end
+  end
+
+  context "連携未設定" do
+    it "導線を出し、同期ボタンは出さない" do
+      # 連携未設定（ボタンが出ないのが正しい）
+      author.update!(github_app_installation_id: nil, github_repo_full_name: nil)
+      post = create(:post, user: author, title: "同期テスト", content: "本文")
+
+      visit post_path(post)
+
+      # インストール導線（リンク or ボタン）の存在
+      expect(page).to(
+        have_link("GitHub App をインストール").or have_button("GitHub App をインストール")
+      )
+
+      # 同期ボタンは出ない
+      expect(page).not_to have_button("GitHubに同期")
+    end
+  end
+
+  context "権限不足や404等" do
+    it "権限不足/NotFound ならエラーフラッシュ表示" do
+      author.update!(
+        github_app_installation_id: 123,
+        github_repo_full_name: "owner/repo",
+        github_branch: "main"
+      )
+      post = create(:post, user: author, title: "同期テスト", content: "本文", created_at: Time.current, updated_at: Time.current)
+
+      client = instance_double(Octokit::Client)
+      allow(GithubApp).to receive(:installation_client).with(123).and_return(client)
+
+      # 新規作成フロー（contents は nil）
+      allow(client).to receive(:contents).and_return(nil)
+
+      # パターンA）リポジトリ未発見
+      allow(client).to receive(:create_contents).and_raise(Octokit::NotFound)
+
+      visit post_path(post)
+      click_button "GitHubに同期"
+
+      expect(page).to have_current_path(post_path(post), ignore_query: true, wait: 5)
+      expect(page).to have_content("同期に失敗").or have_content("リポジトリが見つかりません").or have_content("権限")
+    end
+  end
+end

--- a/spec/system/image_upload_spec.rb
+++ b/spec/system/image_upload_spec.rb
@@ -2,7 +2,7 @@
 require "rails_helper"
 
 RSpec.describe "画像アップロード（エディタ統合）", type: :system, js: true do
-  let(:user) { create(:user, :github_authenticated) }
+  let(:user) { create(:user, :with_github_app) }
 
   before do
     # Warden login helper 有効

--- a/spec/system/login_logout_spec.rb
+++ b/spec/system/login_logout_spec.rb
@@ -2,7 +2,7 @@
 require "rails_helper"
 
 RSpec.describe "Login/Logout", type: :system, js: true do
-  let(:user) { create(:user, :github_authenticated, name: "Me") }
+  let(:user) { create(:user, :with_github_app, name: "Me") }
 
   it "未ログイン時はヘッダーに『ログイン』が出る" do
     visit root_path

--- a/spec/system/navigation_search_spec.rb
+++ b/spec/system/navigation_search_spec.rb
@@ -2,7 +2,7 @@
 require "rails_helper"
 
 RSpec.describe "Navigation & Search", type: :system, js: true do
-  let(:user) { create(:user, :github_authenticated) }
+  let(:user) { create(:user, :with_github_app) }
 
   it "検索フォームで絞り込める（タイトル/本文/タグ）" do
     login_as(user, scope: :user)

--- a/spec/system/posts_crud_spec.rb
+++ b/spec/system/posts_crud_spec.rb
@@ -2,7 +2,7 @@
 require "rails_helper"
 
 RSpec.describe "Posts CRUD", type: :system, js: true do
-  let(:user) { create(:user, :github_authenticated) }
+  let(:user) { create(:user, :with_github_app) }
 
   before do
     login_as(user, scope: :user)


### PR DESCRIPTION
## 概要
### Github権限問題の解消
Closes #72 
旧仕様においてはGithubでログイン時にOAuth経由でレポジトリ全体への書き込み権限を求めていた。
しかし、これでは権限が強すぎてしまうため、今回以下のように仕様変更した。
- GithubAppsの使用
  - ログイン時はユーザー名とメールアドレスの読み取りのみ行う
  - Github連携をしたい場合、ユーザー側でGithubAppsをインストールし、連携先のレポジトリを選択できるように修正
