### PR TITLE
コメントによるポイント付与機能追加とデザイン微修正

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -68,6 +68,16 @@
   transition: all 0.2s ease;
 }
 
+.easy-mde-autogrow .CodeMirror { height: auto !important; min-height: var(--editor-min-h, 280px); }
+.easy-mde-autogrow .CodeMirror-scroll { height: auto !important; overflow-y: auto; max-height: 60vh; }
+.easy-mde-autogrow .CodeMirror-wrap pre.CodeMirror-line,
+.easy-mde-autogrow .CodeMirror-wrap pre.CodeMirror-line-like { white-space: pre-wrap; word-break: break-word; }
+
+.easy-mde-preview-autogrow { height: auto !important; max-height: none !important; overflow-y: visible !important; min-height: var(--preview-min-h, 280px); }
+
+.post-editor    { --editor-min-h: 500px; --preview-min-h: 540px; }
+.comment-editor { --editor-min-h: 160px; --preview-min-h: 200px; }
+
 .uploading-indicator {
   color: #f59e0b;
   font-style: italic;

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -15,7 +15,7 @@ module MarkdownHelper
     html = Kramdown::Document.new(processed, {
       input: 'GFM',
       syntax_highlighter: 'rouge',
-      hard_wrap: false,
+      hard_wrap: true,
       auto_ids: true,
       toc_levels: (1..6),
       entity_output: :as_char

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,8 +1,35 @@
 class Comment < ApplicationRecord
   validates :content, presence: true, length: { maximum: 65_535 }
+  validate :only_one_best_answer_per_post, if: :is_best_answer?
   belongs_to :post
   belongs_to :user
   belongs_to :parent_comment, class_name: 'Comment', foreign_key: :parent_id, optional: true
   has_many :replies, class_name: 'Comment', foreign_key: :parent_id, dependent: :destroy
   scope :best_answer, -> { find_by(is_best_answer: true) }
+  after_commit :award_comment_point, on: :create
+
+  private
+
+  def award_comment_point
+    return if post.user_id == user_id
+    user.with_lock do
+      has_earlier =
+        Comment.where(user_id: user_id, post_id: post_id)
+              .where('id < ?', id)
+              .exists?
+
+      unless has_earlier
+        user.increment!(:points, 1)
+        user.cat&.update_level
+      end
+    end
+  rescue => e
+    Rails.logger.error("[Points] failed to award on comment_id=#{id}: #{e.class} #{e.message}")
+  end
+
+  def only_one_best_answer_per_post
+    if Comment.where(post_id: post_id, is_best_answer: true).where.not(id: id).exists?
+      errors.add(:is_best_answer, 'は1件までです')
+    end
+  end
 end

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -5,7 +5,7 @@
       "markdown-editor-images-allowed-value": true,
       "markdown-editor-editor-height-value": 180,
     },
-    class: "grid grid-cols-1 md:grid-cols-2 gap-4" do |f| %>
+    class: "grid grid-cols-1 md:grid-cols-2 gap-4 comment-editor" do |f| %>
 
   <div>
     <%= f.text_area :content,

--- a/app/views/shared/_form.html.erb
+++ b/app/views/shared/_form.html.erb
@@ -6,9 +6,7 @@
       controller: "markdown-editor",
       "markdown-editor-unattached-blobs-value": unattached_blobs_json,
       "markdown-editor-images-allowed-value": true,
-      "markdown-editor-editor-height-value": 500,
-      "markdown-editor-preview-height-value": 540
-    } do |f| %>
+    }, class: "post-editor" do |f| %>
     <div class="mb-6">
       <label for="post_title" class="block text-sm font-medium text-terminal-text mb-2" >
         タイトル
@@ -45,7 +43,7 @@
         <div id="preview-container"
             class="prose prose-invert max-w-none
                   border border-terminal-border rounded-lg
-                bg-terminal-input p-6 overflow-y-auto shadow-sm
+                bg-terminal-input p-6 shadow-sm
                 prose-headings:text-terminal-text
                 prose-a:text-terminal-accent
                 prose-p: text-terminal-text

--- a/spec/system/image_upload_spec.rb
+++ b/spec/system/image_upload_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "画像アップロード（エディタ統合）", type: :system
     find(".editor-toolbar .fa-upload", wait: 5).click
 
     # Stimulus が動的に挿した input を掴む（class があればそれを、無ければ type=file で拾う）
-    input = page.first('input.test-upload-input', visible: :all)
+    input = page.first('input.upload-input', visible: :all)
     input ||= page.find('input[type="file"]', visible: :all, wait: 5)
 
     input.set(Rails.root.join("spec/fixtures/files/sample.jpg"))


### PR DESCRIPTION
## 概要
### コメントによるポイント付与機能実装
コメント機能によるポイント付与について新たに追加、モデル側に責任を持たせるようにコードを修正し、
一投稿につき付与されるポイントの上限を設けた。しかし、すべてのコメントを削除し、再投稿した場合の制限については現在未対応のためイシューにあげて対応をする。
その他デザインに関してもエディタが2つ表示されることがある問題など対応